### PR TITLE
Add proper type resolving and word import

### DIFF
--- a/studio-client/pom.xml
+++ b/studio-client/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.coremedia.blueprint</groupId>
     <artifactId>studio-client.extensions</artifactId>
     <version>1-SNAPSHOT</version>
+    <relativePath>../../../../apps/studio-client/modules/extensions/pom.xml</relativePath>
   </parent>
 
   <groupId>com.coremedia.blueprint.contenthub</groupId>

--- a/studio-server/pom.xml
+++ b/studio-server/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.coremedia.blueprint</groupId>
     <artifactId>studio-server.extensions</artifactId>
     <version>1-SNAPSHOT</version>
+    <relativePath>../../../../apps/studio-server/modules/extensions/pom.xml</relativePath>
   </parent>
 
   <groupId>com.coremedia.blueprint.contenthub</groupId>

--- a/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxConfiguration.java
+++ b/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxConfiguration.java
@@ -1,13 +1,15 @@
 package com.coremedia.blueprint.contenthub.adapters.dropbox;
 
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
+import com.coremedia.contenthub.api.ContentHubMimeTypeService;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class DropboxConfiguration {
   @Bean
-  public ContentHubAdapterFactory dropboxContentHubAdapterFactory() {
-    return new DropboxContentHubAdapterFactory();
+  public ContentHubAdapterFactory dropboxContentHubAdapterFactory(@NonNull ContentHubMimeTypeService mimeTypeService) {
+    return new DropboxContentHubAdapterFactory(mimeTypeService);
   }
 }

--- a/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxContentHubAdapter.java
+++ b/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxContentHubAdapter.java
@@ -26,10 +26,12 @@ class DropboxContentHubAdapter implements ContentHubAdapter {
   private final String connectionId;
 
   private DbxClientV2 client;
+  private ContentHubMimeTypeService mimeTypeService;
 
-  DropboxContentHubAdapter(@NonNull DropboxContentHubSettings settings, @NonNull String connectionId) {
+  DropboxContentHubAdapter(@NonNull DropboxContentHubSettings settings, @NonNull String connectionId, @NonNull ContentHubMimeTypeService mimeTypeService) {
     this.settings = settings;
     this.connectionId = connectionId;
+    this.mimeTypeService = mimeTypeService;
 
     String accessToken = settings.getAccessToken();
     String displayName = settings.getDisplayName();
@@ -83,7 +85,7 @@ class DropboxContentHubAdapter implements ContentHubAdapter {
       LOGGER.warn("Dropbox item not found for connector id " + id);
       return null;
     }
-    return new DropboxItem(id, fileMetadata, client);
+    return new DropboxItem(id, fileMetadata, client, mimeTypeService);
   }
 
   @Nullable
@@ -109,7 +111,7 @@ class DropboxContentHubAdapter implements ContentHubAdapter {
           children.add(new DropboxFolder(id, entry, entry.getName()));
         }
         else {
-          children.add(new DropboxItem(id, entry, client));
+          children.add(new DropboxItem(id, entry, client, mimeTypeService));
         }
       }
 

--- a/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxContentHubAdapterFactory.java
+++ b/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxContentHubAdapterFactory.java
@@ -2,12 +2,19 @@ package com.coremedia.blueprint.contenthub.adapters.dropbox;
 
 import com.coremedia.contenthub.api.ContentHubAdapter;
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
+import com.coremedia.contenthub.api.ContentHubMimeTypeService;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  *
  */
 class DropboxContentHubAdapterFactory implements ContentHubAdapterFactory<DropboxContentHubSettings> {
+
+  ContentHubMimeTypeService mimeTypeService;
+
+  public DropboxContentHubAdapterFactory(ContentHubMimeTypeService mimeTypeService) {
+    this.mimeTypeService = mimeTypeService;
+  }
 
   @Override
   @NonNull
@@ -19,7 +26,7 @@ class DropboxContentHubAdapterFactory implements ContentHubAdapterFactory<Dropbo
   @Override
   public ContentHubAdapter createAdapter(@NonNull DropboxContentHubSettings settings,
                                          @NonNull String connectionId) {
-    return new DropboxContentHubAdapter(settings, connectionId);
+    return new DropboxContentHubAdapter(settings, connectionId, mimeTypeService);
   }
 
 }

--- a/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxContentHubTransformer.java
+++ b/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxContentHubTransformer.java
@@ -65,6 +65,10 @@ class DropboxContentHubTransformer implements ContentHubTransformer {
       contentModel.put("detailText", ContentCreationUtil.convertStringToRichtext(description));
     }
 
+    ContentHubBlob fileBlob = item.getBlob("data");
+    if (fileBlob != null) {
+      contentModel.put("data", fileBlob);
+    }
     //add additional properties
     additionalProps.forEach(contentModel::put);
 

--- a/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxItem.java
+++ b/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxItem.java
@@ -7,6 +7,7 @@ import com.coremedia.contenthub.api.exception.ContentHubException;
 import com.coremedia.contenthub.api.preview.DetailsElement;
 import com.coremedia.contenthub.api.preview.DetailsSection;
 import com.coremedia.mimetype.TikaMimeTypeService;
+import com.dropbox.core.DbxDownloader;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.files.Dimensions;
@@ -14,6 +15,8 @@ import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.v2.files.Metadata;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.util.HtmlUtils;
 
 import javax.activation.MimeType;
@@ -21,11 +24,14 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 class DropboxItem extends DropboxHubObject implements Item {
+  private static final Logger LOG = LoggerFactory.getLogger(DropboxItem.class);
   private static final WordAbbreviator ABBREVIATOR = new WordAbbreviator();
   private static final int BLOB_SIZE_LIMIT = 10000000;
   private FileMetadata fileMetadata;
   private TikaMimeTypeService tikaservice;
   private ContentHubMimeTypeService mimeTypeService;
+
+  public static final String CLASSIFIER_PREVIEW = "preview";
 
   DropboxItem(ContentHubObjectId id, Metadata metadata, DbxClientV2 client, ContentHubMimeTypeService mimeTypeService) {
     super(id, metadata);
@@ -101,14 +107,36 @@ class DropboxItem extends DropboxHubObject implements Item {
             ).stream().filter(p -> Objects.nonNull(p.getValue())).collect(Collectors.toUnmodifiableList())));
   }
 
-
   @Nullable
   @Override
   public ContentHubBlob getBlob(String classifier) {
+    if (CLASSIFIER_PREVIEW.equals(classifier)) {
+      return getPreviewBlob();
+    }
+
+    MimeType contentType = mimeTypeService.mimeTypeForResourceName(getName());
+    long size = fileMetadata.getSize();
     try {
-      return new UrlBlobBuilder(this, classifier).withUrl(getClient().sharing().getFileMetadata(fileMetadata.getPathDisplay()).getPreviewUrl()).withEtag().build();
+      DbxDownloader<FileMetadata> downloader = getClient().files().download(getPathDisplay());
+      ContentHubBlob blob = new ContentHubDefaultBlob(
+              this,
+              classifier,
+              contentType,
+              size,
+              downloader::getInputStream,
+              null);
+      return blob;
+    } catch(IllegalArgumentException | DbxException e) {
+      LOG.error("Cannot create preview blob for {}. {}", fileMetadata, e);
+    }
+    return null;
+  }
+
+  private ContentHubBlob getPreviewBlob() {
+    try {
+      return new UrlBlobBuilder(this, CLASSIFIER_PREVIEW).withUrl(getClient().sharing().getFileMetadata(fileMetadata.getPathDisplay()).getPreviewUrl()).withEtag().build();
     } catch (DbxException e) {
-      e.printStackTrace();
+      LOG.error("Cannot create preview blob for {}. {}", fileMetadata, e);
     }
 
     return null;

--- a/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxItem.java
+++ b/studio-server/src/main/java/com/coremedia/blueprint/contenthub/adapters/dropbox/DropboxItem.java
@@ -16,6 +16,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.springframework.web.util.HtmlUtils;
 
+import javax.activation.MimeType;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -24,13 +25,15 @@ class DropboxItem extends DropboxHubObject implements Item {
   private static final int BLOB_SIZE_LIMIT = 10000000;
   private FileMetadata fileMetadata;
   private TikaMimeTypeService tikaservice;
+  private ContentHubMimeTypeService mimeTypeService;
 
-  DropboxItem(ContentHubObjectId id, Metadata metadata, DbxClientV2 client) {
+  DropboxItem(ContentHubObjectId id, Metadata metadata, DbxClientV2 client, ContentHubMimeTypeService mimeTypeService) {
     super(id, metadata);
     setClient(client);
     this.fileMetadata = (FileMetadata) getFileMetadata(id);
     this.tikaservice = new TikaMimeTypeService();
     tikaservice.init();
+    this.mimeTypeService = mimeTypeService;
   }
 
   FileMetadata getFileMetadata() {
@@ -40,7 +43,9 @@ class DropboxItem extends DropboxHubObject implements Item {
   @NonNull
   @Override
   public ContentHubType getContentHubType() {
-    return new ContentHubType("dbx_file");
+    MimeType mimeType = this.mimeTypeService.mimeTypeForResourceName(this.getName());
+    return "*".equals(mimeType.getSubType()) ? new ContentHubType(mimeType.getPrimaryType()) : new ContentHubType(mimeType.getSubType(), new ContentHubType(mimeType.getPrimaryType()));
+
   }
 
   @NonNull


### PR DESCRIPTION
This PR adds two main funcitonalities: 
1. Proper type resolving
When browsing through the conntector in the library, it only knew two types of items: Folders and Files. Now, files have been split by mimetype: 
![image](https://user-images.githubusercontent.com/3169254/109952074-ba976500-7cde-11eb-848b-dcce4e7ff804.png)

2. Importing a word file will extract the word text and add it to the detail text. It will also extract embedded images into separate content entities. 
It does so by using the preexisting WordUploadInterceptor. 