### PR TITLE
Enable proper type resolving and word-extraction of articles

### DIFF
--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxConfiguration.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxConfiguration.java
@@ -1,13 +1,36 @@
 package com.coremedia.labs.plugins.adapters.dropbox.server;
 
+import com.coremedia.contenthub.api.BaseFileSystemConfiguration;
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
+import com.coremedia.contenthub.api.ContentHubMimeTypeService;
+import com.coremedia.contenthub.api.ContentHubType;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.util.Map;
 
 @Configuration
+@Import({BaseFileSystemConfiguration.class})
 public class DropboxConfiguration {
+
+  private static Map<ContentHubType, String> typeMapping() {
+    return Map.of(
+            new ContentHubType("default"), "CMDownload",
+            new ContentHubType("audio"), "CMAudio",
+            new ContentHubType("css", new ContentHubType("text")), "CMCSS",
+            new ContentHubType("html", new ContentHubType("text")), "CMHTML",
+            new ContentHubType("javascript", new ContentHubType("text")), "CMJavaScript",
+            new ContentHubType("image"), "CMPicture",
+            new ContentHubType("video"), "CMVideo",
+            new ContentHubType("msword", new ContentHubType("application")), "CMArticle",
+            new ContentHubType("vnd.openxmlformats-officedocument.wordprocessingml.document", new ContentHubType("application")), "CMArticle"
+    );
+  }
+
   @Bean
-  public ContentHubAdapterFactory<?> dropboxContentHubAdapterFactory() {
-    return new DropboxContentHubAdapterFactory();
+  public ContentHubAdapterFactory<?> dropboxContentHubAdapterFactory(@NonNull ContentHubMimeTypeService mimeTypeService) {
+    return new DropboxContentHubAdapterFactory(mimeTypeService, typeMapping());
   }
 }

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubAdapter.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubAdapter.java
@@ -1,6 +1,15 @@
 package com.coremedia.labs.plugins.adapters.dropbox.server;
 
-import com.coremedia.contenthub.api.*;
+import com.coremedia.contenthub.api.ContentHubAdapter;
+import com.coremedia.contenthub.api.ContentHubContext;
+import com.coremedia.contenthub.api.ContentHubMimeTypeService;
+import com.coremedia.contenthub.api.ContentHubObject;
+import com.coremedia.contenthub.api.ContentHubObjectId;
+import com.coremedia.contenthub.api.ContentHubTransformer;
+import com.coremedia.contenthub.api.ContentHubType;
+import com.coremedia.contenthub.api.Folder;
+import com.coremedia.contenthub.api.GetChildrenResult;
+import com.coremedia.contenthub.api.Item;
 import com.coremedia.contenthub.api.exception.ContentHubException;
 import com.coremedia.contenthub.api.pagination.PaginationRequest;
 import com.dropbox.core.DbxException;

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubAdapterFactory.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubAdapterFactory.java
@@ -2,12 +2,25 @@ package com.coremedia.labs.plugins.adapters.dropbox.server;
 
 import com.coremedia.contenthub.api.ContentHubAdapter;
 import com.coremedia.contenthub.api.ContentHubAdapterFactory;
+import com.coremedia.contenthub.api.ContentHubMimeTypeService;
+import com.coremedia.contenthub.api.ContentHubType;
 import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.Map;
 
 /**
  *
  */
 class DropboxContentHubAdapterFactory implements ContentHubAdapterFactory<DropboxContentHubSettings> {
+
+  ContentHubMimeTypeService mimeTypeService;
+  private final Map<ContentHubType, String> typeMapping;
+
+  public DropboxContentHubAdapterFactory(ContentHubMimeTypeService mimeTypeService,
+                                         Map<ContentHubType, String> typeMapping) {
+    this.mimeTypeService = mimeTypeService;
+    this.typeMapping = typeMapping;
+  }
 
   @Override
   @NonNull
@@ -19,7 +32,7 @@ class DropboxContentHubAdapterFactory implements ContentHubAdapterFactory<Dropbo
   @Override
   public ContentHubAdapter createAdapter(@NonNull DropboxContentHubSettings settings,
                                          @NonNull String connectionId) {
-    return new DropboxContentHubAdapter(settings, connectionId);
+    return new DropboxContentHubAdapter(settings, connectionId, mimeTypeService, typeMapping);
   }
 
 }

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubTransformer.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubTransformer.java
@@ -1,15 +1,7 @@
 package com.coremedia.labs.plugins.adapters.dropbox.server;
 
 import com.coremedia.cap.common.Blob;
-import com.coremedia.contenthub.api.ContentCreationUtil;
-import com.coremedia.contenthub.api.ContentHubAdapter;
-import com.coremedia.contenthub.api.ContentHubContext;
-import com.coremedia.contenthub.api.ContentHubObject;
-import com.coremedia.contenthub.api.ContentHubTransformer;
-import com.coremedia.contenthub.api.ContentModel;
-import com.coremedia.contenthub.api.ContentModelReference;
-import com.coremedia.contenthub.api.Item;
-import com.coremedia.contenthub.api.UrlBlobBuilder;
+import com.coremedia.contenthub.api.*;
 import com.coremedia.cotopaxi.common.blobs.BlobServiceImpl;
 import com.coremedia.mimetype.TikaMimeTypeService;
 import com.coremedia.util.TempFileFactory;
@@ -75,6 +67,10 @@ class DropboxContentHubTransformer implements ContentHubTransformer {
       contentModel.put("detailText", ContentCreationUtil.convertStringToRichtext(description));
     }
 
+    ContentHubBlob fileBlob = item.getBlob("data");
+    if (fileBlob != null) {
+      contentModel.put("data", fileBlob);
+    }
     //add additional properties
     additionalProps.forEach(contentModel::put);
 

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubTransformer.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxContentHubTransformer.java
@@ -1,7 +1,16 @@
 package com.coremedia.labs.plugins.adapters.dropbox.server;
 
 import com.coremedia.cap.common.Blob;
-import com.coremedia.contenthub.api.*;
+import com.coremedia.contenthub.api.ContentCreationUtil;
+import com.coremedia.contenthub.api.ContentHubAdapter;
+import com.coremedia.contenthub.api.ContentHubBlob;
+import com.coremedia.contenthub.api.ContentHubContext;
+import com.coremedia.contenthub.api.ContentHubObject;
+import com.coremedia.contenthub.api.ContentHubTransformer;
+import com.coremedia.contenthub.api.ContentModel;
+import com.coremedia.contenthub.api.ContentModelReference;
+import com.coremedia.contenthub.api.Item;
+import com.coremedia.contenthub.api.UrlBlobBuilder;
 import com.coremedia.cotopaxi.common.blobs.BlobServiceImpl;
 import com.coremedia.mimetype.TikaMimeTypeService;
 import com.coremedia.util.TempFileFactory;

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxFolder.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxFolder.java
@@ -13,7 +13,6 @@ class DropboxFolder extends DropboxHubObject implements Folder {
 
   DropboxFolder(ContentHubObjectId id, Metadata metadata, String name) {
     super(id, metadata);
-    setName(name);
     if (metadata == null) {
       isRoot = true;
     }

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxHubObject.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxHubObject.java
@@ -1,23 +1,21 @@
 package com.coremedia.labs.plugins.adapters.dropbox.server;
 
 
+import com.coremedia.contenthub.api.BaseFileSystemHubObject;
 import com.coremedia.contenthub.api.ContentHubObject;
 import com.coremedia.contenthub.api.ContentHubObjectId;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.files.Metadata;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-abstract class DropboxHubObject implements ContentHubObject {
+abstract class DropboxHubObject extends BaseFileSystemHubObject implements ContentHubObject {
 
-  private final ContentHubObjectId hubId;
-  private String name;
   private String pathDisplay;
   private DbxClientV2 client;
 
   DropboxHubObject(ContentHubObjectId hubId, Metadata metadata) {
-    this.hubId = hubId;
+    super(hubId, metadata != null? metadata.getName(): "root");
     if (metadata != null) {  //ROOT
-      this.name = metadata.getName();
       this.pathDisplay = metadata.getPathDisplay();
     }
 
@@ -25,24 +23,8 @@ abstract class DropboxHubObject implements ContentHubObject {
 
   @NonNull
   @Override
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  @NonNull
-  @Override
   public String getDisplayName() {
     return getName();
-  }
-
-  @NonNull
-  @Override
-  public ContentHubObjectId getId() {
-    return hubId;
   }
 
   @NonNull

--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxItem.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/dropbox/server/DropboxItem.java
@@ -7,6 +7,7 @@ import com.coremedia.contenthub.api.exception.ContentHubException;
 import com.coremedia.contenthub.api.preview.DetailsElement;
 import com.coremedia.contenthub.api.preview.DetailsSection;
 import com.coremedia.mimetype.TikaMimeTypeService;
+import com.dropbox.core.DbxDownloader;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.v2.DbxClientV2;
 import com.dropbox.core.v2.files.Dimensions;
@@ -14,18 +15,25 @@ import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.v2.files.Metadata;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.util.HtmlUtils;
 
+import javax.activation.MimeType;
 import java.util.*;
 import java.util.stream.Collectors;
 
+
 class DropboxItem extends BaseFileSystemItem implements Item {
+  private static final Logger LOG = LoggerFactory.getLogger(DropboxItem.class);
   private static final WordAbbreviator ABBREVIATOR = new WordAbbreviator();
   private static final int BLOB_SIZE_LIMIT = 10000000;
   private final FileMetadata fileMetadata;
   private final TikaMimeTypeService tikaservice;
   private ContentHubMimeTypeService mimeTypeService;
   private DbxClientV2 client;
+
+  public static final String CLASSIFIER_PREVIEW = "preview";
 
   DropboxItem(ContentHubObjectId id,
               Metadata metadata,
@@ -98,14 +106,36 @@ class DropboxItem extends BaseFileSystemItem implements Item {
             ).stream().filter(p -> Objects.nonNull(p.getValue())).collect(Collectors.toUnmodifiableList())));
   }
 
-
   @Nullable
   @Override
   public ContentHubBlob getBlob(String classifier) {
+    if (CLASSIFIER_PREVIEW.equals(classifier)) {
+      return getPreviewBlob();
+    }
+
+    MimeType contentType = mimeTypeService.mimeTypeForResourceName(getName());
+    long size = fileMetadata.getSize();
     try {
-      return new UrlBlobBuilder(this, classifier).withUrl(getClient().sharing().getFileMetadata(fileMetadata.getPathDisplay()).getPreviewUrl()).withEtag().build();
+      DbxDownloader<FileMetadata> downloader = getClient().files().download(fileMetadata.getPathDisplay());
+      ContentHubBlob blob = new ContentHubDefaultBlob(
+              this,
+              classifier,
+              contentType,
+              size,
+              downloader::getInputStream,
+              null);
+      return blob;
+    } catch(IllegalArgumentException | DbxException e) {
+      LOG.error("Cannot create preview blob for {}. {}", fileMetadata, e);
+    }
+    return null;
+  }
+
+  private ContentHubBlob getPreviewBlob() {
+    try {
+      return new UrlBlobBuilder(this, CLASSIFIER_PREVIEW).withUrl(getClient().sharing().getFileMetadata(fileMetadata.getPathDisplay()).getPreviewUrl()).withEtag().build();
     } catch (DbxException e) {
-      e.printStackTrace();
+      LOG.error("Cannot create preview blob for {}. {}", fileMetadata, e);
     }
 
     return null;


### PR DESCRIPTION
Before this, the Dropbox Adapter only knows one type: File. Leveraging the ContentHubMimeTypeService, we now get proper types: 
![image](https://user-images.githubusercontent.com/3169254/114995685-60bdb980-9e9e-11eb-852b-7970919a0bad.png)
(nevermind the cryptic word type, the Studio I took this screenshot from was missing some localization bundles). 

Additionally, importing a docx file would only set the title of the newly created article to the name of the file, and write the same string into the detail text. We now delegate content creation of word files to the WordUploadInterceptor. 